### PR TITLE
Fix coordinator-worker gaps across 3 skill groups

### DIFF
--- a/ln-200-scope-decomposer/SKILL.md
+++ b/ln-200-scope-decomposer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ln-200-scope-decomposer
-description: Orchestrates full decomposition (scope → Epics → Stories) by delegating ln-210 → ln-220. Sequential Story decomposition per Epic. Epic 0 for Infrastructure.
+description: "Orchestrates full decomposition (scope → Epics → Stories → RICE prioritization) by delegating ln-210 → ln-220 → ln-230. Sequential processing. Epic 0 for Infrastructure."
 ---
 
 > **Paths:** File paths (`shared/`, `references/`, `../ln-*`) are relative to skills repo root. If not found at CWD, locate this SKILL.md directory and go up one level for repo root.
@@ -18,7 +18,8 @@ Coordinates the complete decomposition pipeline for new initiatives:
 - **Phase 1:** Discovery (Team ID)
 - **Phase 2:** Epic Decomposition (delegates to ln-210-epic-coordinator)
 - **Phase 3:** Story Decomposition Loop (delegates to ln-220-story-coordinator per Epic, sequential)
-- **Phase 4:** Summary (total counts + next steps)
+- **Phase 4:** RICE Prioritization Loop (optional, delegates to ln-230-story-prioritizer per Epic, sequential)
+- **Phase 5:** Summary (total counts + next steps)
 
 ### When to Use This Skill
 
@@ -31,6 +32,7 @@ This skill should be used when:
 **Alternative:** For granular control, invoke coordinators manually:
 1. [ln-210-epic-coordinator](../ln-210-epic-coordinator/SKILL.md) - CREATE/REPLAN Epics
 2. [ln-220-story-coordinator](../ln-220-story-coordinator/SKILL.md) - CREATE/REPLAN Stories (once per Epic)
+3. [ln-230-story-prioritizer](../ln-230-story-prioritizer/SKILL.md) - RICE prioritization (once per Epic)
 
 ### When NOT to Use
 
@@ -49,7 +51,7 @@ Do NOT use if:
 **ln-200-scope-decomposer is a pure coordinator** - it does NOT execute work directly:
 - ✅ Discovers context (Team ID)
 - ✅ Makes routing decisions (which coordinator to invoke)
-- ✅ Delegates all work via Skill tool (ln-210, ln-220)
+- ✅ Delegates all work via Skill tool (ln-210, ln-220, ln-230)
 - ✅ Manages workflow state (Epic creation → Story loop)
 - ❌ Does NOT research project docs (ln-210 does this)
 - ❌ Does NOT generate Epic/Story documents (ln-210/ln-220 do this)
@@ -171,11 +173,47 @@ Add phases and Epic iterations to todos before starting:
 - Phase 3: Delegate to ln-220 for Epic 1 (pending)
 - Phase 3: Delegate to ln-220 for Epic 2 (pending)
 ... (one todo per Epic)
-- Phase 4: Summary (pending)
+- Phase 4: Delegate to ln-230 for Epic 0 (pending)
+- Phase 4: Delegate to ln-230 for Epic 1 (pending)
+... (one todo per Epic, optional)
+- Phase 5: Summary (pending)
 ```
 Mark each as in_progress when starting, completed when coordinator returns success.
 
-### Phase 4: Summary and Next Steps
+### Phase 4: RICE Prioritization Loop (Optional, Sequential, Delegated)
+
+**Objective:** Prioritize Stories per Epic using RICE scoring with market research.
+
+> **OPTIONAL:** Ask user "Run RICE prioritization for all Epics?" If user declines, skip to Phase 5.
+
+**Sequential Loop Logic:**
+
+```
+FOR EACH Epic (Epic 0, Epic 1, ..., Epic N):
+    1. Invoke ln-230-story-prioritizer for current Epic
+    2. Wait for completion
+    3. Verify prioritization.md created in docs/market/[epic-slug]/
+    4. Move to next Epic
+```
+
+**Invocation per Epic:**
+```
+Skill(skill: "ln-230-story-prioritizer", args: "epic=\"Epic N\"")
+```
+
+**ln-230-story-prioritizer will (per Epic):**
+- Load Stories metadata from Linear
+- Research market size and competition per Story
+- Calculate RICE score and assign Priority (P0-P3)
+- Generate docs/market/[epic-slug]/prioritization.md
+
+**Skip condition:** If Epic contains only technical/infrastructure Stories (no business value to prioritize), skip that Epic.
+
+**After each Epic:** Prioritization table saved to docs/market/[epic-slug]/prioritization.md.
+
+**Output:** Prioritization tables for all applicable Epics.
+
+### Phase 5: Summary and Next Steps
 
 **Objective:** Provide complete decomposition overview.
 
@@ -263,7 +301,12 @@ Before completing work, verify ALL checkpoints:
 - [ ] Story URLs returned for each Epic
 - [ ] All Stories visible in kanban_board.md (Backlog section)
 
-**✅ Summary Provided (Phase 4):**
+**✅ RICE Prioritization Complete (Phase 4, optional):**
+- [ ] User asked about prioritization (skip if declined)
+- [ ] Delegated to ln-230-story-prioritizer for each applicable Epic
+- [ ] Prioritization tables saved to docs/market/[epic-slug]/
+
+**✅ Summary Provided (Phase 5):**
 - [ ] Total counts displayed (Epics, Stories, breakdown per Epic)
 - [ ] kanban_board.md location shown
 - [ ] Next steps provided (validation, task creation)
@@ -282,6 +325,7 @@ Users directly: "Decompose initiative: [initiative name]" or "Create epics and s
 
 - **ln-210-epic-coordinator** (Phase 2) - CREATE mode (batch Epic creation with batch preview)
 - **ln-220-story-coordinator** (Phase 3, sequential loop) - CREATE mode per Epic (Story creation with preview)
+- **ln-230-story-prioritizer** (Phase 4, optional sequential loop) - RICE prioritization per Epic
 
 ### Downstream
 
@@ -392,6 +436,7 @@ After ln-200-scope-decomposer completes:
 - **Configuration source:** `docs/tasks/kanban_board.md` (Team ID, Next Epic Number)
 - **Epic coordinator:** `ln-210-epic-coordinator/SKILL.md`
 - **Story coordinator:** `ln-220-story-coordinator/SKILL.md`
+- **Story prioritizer:** `ln-230-story-prioritizer/SKILL.md`
 - **Numbering conventions:** `shared/references/numbering_conventions.md` (Epic 0 reserved)
 
 ---

--- a/ln-230-story-prioritizer/SKILL.md
+++ b/ln-230-story-prioritizer/SKILL.md
@@ -31,8 +31,8 @@ Evaluate Stories using RICE scoring with market research. Generate consolidated 
 - Prioritization already exists in docs/market/
 
 **Who calls this skill:**
-- **User (manual)** - after ln-220-story-coordinator
-- **Future:** ln-200-scope-decomposer (optional Phase)
+- **ln-200-scope-decomposer** Phase 4 (optional, sequential per Epic)
+- **User (manual)** - standalone after ln-220-story-coordinator
 
 ---
 

--- a/ln-510-quality-coordinator/SKILL.md
+++ b/ln-510-quality-coordinator/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: ln-510-quality-coordinator
-description: "Coordinates code quality checks: ln-511 code quality, ln-513 agent review, ln-514 regression. Single-pass, returns results to ln-500."
+description: "Coordinates code quality checks: ln-511 code quality, ln-512 tech debt cleanup, ln-513 agent review, ln-514 regression. Sequential pipeline, returns results to ln-500."
 ---
 
 > **Paths:** File paths (`shared/`, `references/`, `../ln-*`) are relative to skills repo root. If not found at CWD, locate this SKILL.md directory and go up one level for repo root.
 
 # Quality Coordinator
 
-Single-pass coordinator for code quality checks. Invokes workers and returns aggregated results to ln-500.
+Sequential coordinator for code quality pipeline. Invokes 4 workers in index order (511 -> 512 -> 513 -> 514) and returns aggregated results to ln-500.
 
 ## Purpose & Scope
-- Invoke ln-511-code-quality-checker (which invokes ln-513 agent-reviewer internally)
+- Invoke ln-511-code-quality-checker (metrics, MCP Ref, static analysis)
+- Invoke ln-512-tech-debt-cleaner (auto-fix safe findings from ln-511)
+- Invoke ln-513-agent-reviewer (external agent reviews on cleaned code)
 - Run Criteria Validation (Story dependencies, AC-Task Coverage, DB Creation Principle)
 - Run linters from tech_stack.md
-- Invoke ln-514-regression-checker
+- Invoke ln-514-regression-checker (test suite after all changes)
 - Return aggregated quality results to ln-500-story-quality-gate
 - **No verdict determination** — ln-500 decides final Gate verdict
 
@@ -28,18 +30,18 @@ Single-pass coordinator for code quality checks. Invokes workers and returns agg
 1) Auto-discover team/config from `docs/tasks/kanban_board.md`
 2) Load Story + task metadata from Linear (no full descriptions)
 
-**Fast-track mode:** When invoked with `--fast-track` flag (readiness 10/10), skip Phase 2 (ln-511/ln-513). Run Phase 3 (criteria), Phase 4 (linters), Phase 5 (ln-514) only.
+**Fast-track mode:** When invoked with `--fast-track` flag (readiness 10/10), skip Phase 2 (ln-511), Phase 3 (ln-512), Phase 4 (ln-513). Run Phase 5 (criteria), Phase 6 (linters), Phase 7 (ln-514) only.
 
 **Input:** Story ID from ln-500-story-quality-gate
 
 ### Phase 2: Code Quality (delegate to ln-511 — SKIP if --fast-track)
 
-> **MANDATORY STEP (full gate):** ln-511 invocation required. ln-511 internally invokes ln-513 for agent review — this chain MUST NOT be broken.
-> **Fast-track:** SKIP this phase entirely (ln-511 + ln-513). Readiness 10/10 = pre-validated code quality.
+> **MANDATORY STEP (full gate):** ln-511 invocation required.
+> **Fast-track:** SKIP this phase. Readiness 10/10 = pre-validated code quality.
 
 1) **Invoke ln-511-code-quality-checker** via Skill tool
    - ln-511 runs code metrics, MCP Ref validation (OPT/BP/PERF), static analysis
-   - ln-511 internally invokes ln-513-agent-reviewer for external agent reviews
+   - Returns verdict (PASS/CONCERNS/ISSUES_FOUND) + code_quality_score + issues list
 2) **If ln-511 returns ISSUES_FOUND** -> aggregate issues, continue (ln-500 decides action)
 
 **Invocation:**
@@ -47,7 +49,40 @@ Single-pass coordinator for code quality checks. Invokes workers and returns agg
 Skill(skill: "ln-511-code-quality-checker", args: "{storyId}")
 ```
 
-### Phase 3: Criteria Validation
+### Phase 3: Tech Debt Cleanup (delegate to ln-512 — SKIP if --fast-track)
+
+> **MANDATORY STEP (full gate):** ln-512 invocation required. Safe auto-fixes only (confidence >=90%).
+> **Fast-track:** SKIP this phase.
+
+1) **Invoke ln-512-tech-debt-cleaner** via Skill tool
+   - ln-512 consumes findings from ln-511 output (passed via coordinator context)
+   - Filters to auto-fixable categories (unused imports, dead code, deprecated aliases)
+   - Applies safe fixes, verifies build integrity, creates commit
+2) **If ln-512 returns BUILD_FAILED** -> all changes reverted, aggregate issue, continue
+
+**Invocation:**
+```
+Skill(skill: "ln-512-tech-debt-cleaner", args: "{storyId}")
+```
+
+### Phase 4: Agent Review (delegate to ln-513 — SKIP if --fast-track)
+
+> **MANDATORY STEP (full gate):** ln-513 invocation required. Returns SKIPPED gracefully if agents unavailable.
+> **Fast-track:** SKIP this phase.
+
+1) **Invoke ln-513-agent-reviewer** via Skill tool
+   - ln-513 runs external agents (Codex + Gemini) in parallel on cleaned code
+   - Critically verifies each suggestion, debates if disagreeing
+   - Returns filtered suggestions with confidence scoring
+2) **Merge suggestions into issues list** (same prefixes: SEC-, PERF-, MNT-, ARCH-, BP-, OPT-)
+3) **If verdict = SUGGESTIONS with area=security or area=correctness** -> escalate aggregate to CONCERNS
+
+**Invocation:**
+```
+Skill(skill: "ln-513-agent-reviewer", args: "{storyId}")
+```
+
+### Phase 5: Criteria Validation
 
 **MANDATORY READ:** Load `references/criteria_validation.md`
 
@@ -57,17 +92,18 @@ Skill(skill: "ln-511-code-quality-checker", args: "{storyId}")
 | #2 AC-Task Coverage | STRONG/WEAK/MISSING scoring | [COV-]/[BUG-] issue |
 | #3 DB Creation Principle | Schema scope matches Story | [DB-] issue |
 
-### Phase 4: Linters
+### Phase 6: Linters
 **MANDATORY READ:** `shared/references/ci_tool_detection.md` (Discovery Hierarchy + Command Registry)
 
 1) Detect lint/typecheck commands per ci_tool_detection.md discovery hierarchy
 2) Run all detected checks (timeouts per guide: 2min linters, 5min typecheck)
 3) **If any check fails** -> aggregate issues, continue
 
-### Phase 5: Regression Tests (delegate to ln-514)
+### Phase 7: Regression Tests (delegate to ln-514)
 
 1) **Invoke ln-514-regression-checker** via Skill tool
    - Runs full test suite, reports PASS/FAIL
+   - Runs AFTER ln-512 changes to verify nothing broke
 2) **If regression FAIL** -> aggregate issues, continue
 
 **Invocation:**
@@ -75,18 +111,21 @@ Skill(skill: "ln-511-code-quality-checker", args: "{storyId}")
 Skill(skill: "ln-514-regression-checker", args: "{storyId}")
 ```
 
-### Phase 6: Return Results
+### Phase 8: Return Results
 
 Return aggregated results to ln-500:
 
 ```yaml
 quality_check: PASS | CONCERNS | ISSUES_FOUND
 code_quality_score: {0-100}
+agent_review: CODE_ACCEPTABLE | SUGGESTIONS | SKIPPED
 criteria_validation: PASS | FAIL
 linters: PASS | FAIL
+tech_debt_cleanup: CLEANED | NOTHING_TO_CLEAN | BUILD_FAILED | SKIPPED
 regression: PASS | FAIL
 issues:
   - {id: "SEC-001", severity: high, finding: "...", source: "ln-511"}
+  - {id: "OPT-001", severity: medium, finding: "...", source: "ln-513"}
   - {id: "DEP-001", severity: medium, finding: "...", source: "criteria"}
   - {id: "LINT-001", severity: low, finding: "...", source: "linters"}
 ```
@@ -94,6 +133,8 @@ issues:
 **TodoWrite format (mandatory):**
 ```
 - Invoke ln-511-code-quality-checker (in_progress)
+- Invoke ln-512-tech-debt-cleaner (pending)
+- Invoke ln-513-agent-reviewer (pending)
 - Criteria Validation (Story deps, AC coverage, DB schema) (pending)
 - Run linters from tech_stack.md (pending)
 - Invoke ln-514-regression-checker (pending)
@@ -102,15 +143,19 @@ issues:
 
 ## Worker Invocation (MANDATORY)
 
-| Step | Worker | Context |
-|------|--------|---------|
-| Code Quality | ln-511-code-quality-checker | Shared (Skill tool) — delegates agent review to ln-513 |
-| Regression | ln-514-regression-checker | Shared (Skill tool) |
+| Phase | Worker | Context |
+|-------|--------|---------|
+| 2 | ln-511-code-quality-checker | Shared (Skill tool) — code metrics, MCP Ref, static analysis |
+| 3 | ln-512-tech-debt-cleaner | Shared (Skill tool) — auto-fix safe findings from ln-511 |
+| 4 | ln-513-agent-reviewer | Shared (Skill tool) — external agent reviews on cleaned code |
+| 7 | ln-514-regression-checker | Shared (Skill tool) — full test suite after all changes |
 
-**All workers:** Invoke via Skill tool — workers see coordinator context. ln-513 is invoked by ln-511 internally.
+**All workers:** Invoke via Skill tool — workers see coordinator context. Sequential execution: 511 -> 512 -> 513 -> 514.
 
 **Anti-Patterns:**
 - Running mypy, ruff, pytest directly instead of invoking ln-511/ln-514
+- Running agent reviews directly instead of invoking ln-513
+- Auto-fixing code directly instead of invoking ln-512
 - Marking steps as completed without invoking the actual skill
 - Determining final verdict (that's ln-500's responsibility)
 
@@ -122,6 +167,8 @@ issues:
 
 ## Definition of Done
 - ln-511 invoked (or skipped if --fast-track), code quality score returned
+- ln-512 invoked (or skipped if --fast-track), tech debt cleanup results returned
+- ln-513 invoked (or skipped if --fast-track), agent review results returned
 - Criteria Validation completed (3 checks)
 - Linters executed
 - ln-514 invoked, regression results returned
@@ -130,7 +177,7 @@ issues:
 ## Reference Files
 - Criteria Validation: `references/criteria_validation.md`
 - Gate levels: `references/gate_levels.md`
-- Workers: `../ln-511-code-quality-checker/SKILL.md`, `../ln-513-agent-reviewer/SKILL.md`, `../ln-514-regression-checker/SKILL.md`
+- Workers: `../ln-511-code-quality-checker/SKILL.md`, `../ln-512-tech-debt-cleaner/SKILL.md`, `../ln-513-agent-reviewer/SKILL.md`, `../ln-514-regression-checker/SKILL.md`
 - Caller: `../ln-500-story-quality-gate/SKILL.md`
 - Test planning (separate coordinator): `../ln-520-test-planner/SKILL.md`
 - Tech stack/linters: `docs/project/tech_stack.md`

--- a/ln-511-code-quality-checker/SKILL.md
+++ b/ln-511-code-quality-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ln-511-code-quality-checker
-description: "Worker that checks DRY/KISS/YAGNI/architecture compliance with quantitative Code Quality Score. Validates architectural decisions via MCP Ref: (1) Optimality - is chosen approach the best? (2) Compliance - does it follow best practices? (3) Performance - algorithms, configs, bottlenecks. Reports issues with SEC-, PERF-, MNT-, ARCH-, BP-, OPT- prefixes."
+description: "Worker that checks DRY/KISS/YAGNI/architecture compliance with quantitative Code Quality Score. Validates architectural decisions via MCP Ref: (1) Optimality (2) Compliance (3) Performance. Reports issues with SEC-, PERF-, MNT-, ARCH-, BP-, OPT- prefixes."
 ---
 
 > **Paths:** File paths (`shared/`, `references/`, `../ln-*`) are relative to skills repo root. If not found at CWD, locate this SKILL.md directory and go up one level for repo root.
@@ -90,7 +90,7 @@ Formula: `Code Quality Score = 100 - metric_penalties - issue_penalties`
 ## When to Use
 - **Invoked by ln-510-quality-coordinator** Phase 2
 - All implementation tasks in Story status = Done
-- Before regression testing (ln-514) and test planning (ln-520)
+- Before ln-512 tech debt cleanup and ln-513 agent review
 
 ## Workflow (concise)
 1) Load Story (full) and Done implementation tasks (full descriptions) via Linear; skip tasks with label "tests".
@@ -149,16 +149,6 @@ Formula: `Code Quality Score = 100 - metric_penalties - issue_penalties`
    - Subtract issue penalties (see Issue penalties table)
 
 7) Output verdict with score and structured issues. Add Linear comment with findings.
-8) **Agent Review (MANDATORY — Delegated to ln-513):**
-
-   > **MANDATORY STEP:** This step MUST execute after Step 7. DO NOT skip. If agents unavailable, ln-513 returns SKIPPED — acceptable. But invocation MUST happen.
-
-   Invoke `Skill(skill="ln-513-agent-reviewer", args="{storyId}")`.
-   - ln-513 gets Story/Task references from Linear, builds prompt with references, runs agents in parallel, persists prompts and results in `.agent-review/{agent}/`.
-   - Merge returned suggestions into issues list (same prefixes: SEC-, PERF-, MNT-, ARCH-, BP-, OPT-).
-   - If verdict = `SUGGESTIONS` with `area=security` or `area=correctness` → escalate PASS → CONCERNS.
-   - If verdict = `SKIPPED` → Self-Review fallback (native Claude reviews code).
-   - **Display:** agent stats from ln-513 output.
 
 ## Critical Rules
 - Read guides mentioned in Story/Tasks before judging compliance.
@@ -177,7 +167,6 @@ Formula: `Code Quality Score = 100 - metric_penalties - issue_penalties`
 - ARCH- subcategories checked (LB, TX, DTO, DI, CEH, SES); MNT- subcategories checked (DC, DRY, GOD, SIG, ERR).
 - Issues identified with prefixes and severity, sources from MCP Ref/Context7.
 - Code Quality Score calculated.
-- Agent review: ln-513 invoked; suggestions merged into issues (or SKIPPED/Self-Review fallback).
 - **Output format:**
   ```yaml
   verdict: PASS | CONCERNS | ISSUES_FOUND
@@ -278,10 +267,7 @@ Formula: `Code Quality Score = 100 - metric_penalties - issue_penalties`
 - Code metrics: `references/code_metrics.md` (thresholds and penalties)
 - Guides: `docs/guides/`
 - Templates for context: `shared/templates/task_template_implementation.md`
-- Agent review prompt: `shared/agents/prompt_templates/code_review.md`
-- Agent review schema: `shared/agents/schemas/code_review_schema.json`
 - **Clean code checklist:** `shared/references/clean_code_checklist.md`
-- Agent delegation: `shared/references/agent_delegation_pattern.md`
 
 ---
 **Version:** 5.0.0

--- a/ln-512-tech-debt-cleaner/SKILL.md
+++ b/ln-512-tech-debt-cleaner/SKILL.md
@@ -16,7 +16,7 @@ Automated cleanup of safe, low-risk tech debt findings from codebase audits.
 - **Apply** safe fixes: remove unused imports, delete dead code, clean commented-out blocks, remove deprecated aliases
 - **Never touch** business logic, complex refactoring, or architectural changes
 - **Create** single commit with structured summary of all changes
-- Invocable standalone or from ln-500 quality gate after PASS
+- Invocable from ln-510 quality coordinator pipeline or standalone
 
 ## Auto-Fixable Categories
 
@@ -43,14 +43,14 @@ Automated cleanup of safe, low-risk tech debt findings from codebase audits.
 
 ## When to Use
 
+- **Invoked by ln-510-quality-coordinator** Phase 3 (after ln-511 code quality check)
 - **Standalone:** After `ln-620` codebase audit completes (user triggers manually)
-- **Post-Quality-Gate:** After ln-500 PASS verdict (optional, user-triggered)
 - **Scheduled:** As periodic "garbage collection" for codebase hygiene
 
 ## Inputs
 
-- `docs/project/codebase_audit.md` — primary source (ln-620 output)
-- OR inline findings from ln-511 code quality output (if invoked from quality pipeline)
+- **Pipeline mode (ln-510):** findings from ln-511 code quality output (passed via coordinator context)
+- **Standalone mode:** `docs/project/codebase_audit.md` (ln-620 output)
 
 ## Workflow
 

--- a/ln-513-agent-reviewer/SKILL.md
+++ b/ln-513-agent-reviewer/SKILL.md
@@ -10,7 +10,7 @@ description: "Worker that runs parallel external agent reviews (Codex + Gemini) 
 Runs parallel external agent reviews on code implementation, critically verifies suggestions, returns filtered improvements.
 
 ## Purpose & Scope
-- Worker in ln-510 quality coordinator pipeline (invoked by ln-511 Step 7)
+- Worker in ln-510 quality coordinator pipeline (invoked by ln-510 Phase 4)
 - Run codex-review + gemini-review as background tasks in parallel
 - Process results as they arrive (first-finished agent processed immediately)
 - Critically verify each suggestion; debate with agent if Claude disagrees
@@ -18,9 +18,9 @@ Runs parallel external agent reviews on code implementation, critically verifies
 - Health check + prompt execution in single invocation
 
 ## When to Use
-- **Invoked by ln-511-code-quality-checker** Step 7 (Agent Review)
+- **Invoked by ln-510-quality-coordinator** Phase 4 (Agent Review)
 - All implementation tasks in Story status = Done
-- Code quality analysis (Steps 1-6) already completed by ln-511
+- Code quality (ln-511) and tech debt cleanup (ln-512) already completed
 
 ## Inputs (from parent skill)
 - `storyId`: Linear Story identifier (e.g., "PROJ-123")
@@ -128,11 +128,11 @@ debate_log:
 | Both agents succeed | Aggregate verified suggestions from both |
 | One agent fails | Use successful agent's verified suggestions, log failure |
 | Both agents fail | Return `{verdict: "SKIPPED", reason: "agents failed"}` |
-| Parent skill (ln-511) | Falls back to Self-Review (native Claude) |
+| Parent skill (ln-510) | Falls back to Self-Review (native Claude) |
 
 ## Verdict Escalation
 - Findings with `area=security` or `area=correctness` -> parent skill can escalate PASS -> CONCERNS
-- This skill returns raw verified suggestions; escalation decision is made by ln-511
+- This skill returns raw verified suggestions; escalation decision is made by ln-510
 
 ## Critical Rules
 - Read-only review — agents must NOT modify project files (enforced by prompt CRITICAL CONSTRAINTS)

--- a/ln-630-test-auditor/SKILL.md
+++ b/ln-630-test-auditor/SKILL.md
@@ -172,7 +172,7 @@ ELSE:
 **Parallelism strategy:**
 - Phase 4a: All 4 global workers run in PARALLEL
 - Phase 4b: All N domain-aware invocations run in PARALLEL
-- Example: 3 domains → 3 ln-374 invocations in single message
+- Example: 3 domains → 3 ln-634 invocations in single message
 
 **Worker Output Contract (Unified):**
 
@@ -323,7 +323,7 @@ Each worker:
 
 ## Critical Rules
 
-- **Two-stage delegation:** Global workers (4) + Domain-aware worker (ln-374 × N domains)
+- **Two-stage delegation:** Global workers (4) + Domain-aware worker (ln-634 × N domains)
 - **Domain discovery:** Auto-detect domains from folder structure; fallback to global mode if <2 domains
 - **Parallel execution:** All workers (global + domain-aware) run in PARALLEL
 - **Domain-grouped output:** Coverage Gaps findings grouped by domain (if domain_mode="domain-aware")
@@ -342,7 +342,7 @@ Each worker:
 - Domain discovery completed (domain_mode determined)
 - contextStore built with test metadata + domain info
 - Global workers (4) invoked in PARALLEL
-- Domain-aware worker (ln-374) invoked per domain in PARALLEL
+- Domain-aware worker (ln-634) invoked per domain in PARALLEL
 - All workers completed successfully (or reported errors)
 - Results aggregated with domain grouping (if domain_mode="domain-aware")
 - Domain Coverage Summary built (if domain_mode="domain-aware")

--- a/ln-630-test-auditor/diagram.html
+++ b/ln-630-test-auditor/diagram.html
@@ -17,7 +17,7 @@
         <h3>Overview</h3>
         <p><strong>Purpose:</strong> Coordinates 5 specialized test audit workers with domain-aware coverage gap analysis.</p>
         <p><strong>Type:</strong> Orchestrator-Worker Pattern (L2 Coordinator + 5 L3 Workers)</p>
-        <p><strong>Domain Support:</strong> Auto-detects project domains; runs Coverage Gaps (ln-374) per domain.</p>
+        <p><strong>Domain Support:</strong> Auto-detects project domains; runs Coverage Gaps (ln-634) per domain.</p>
         <p><strong>Invocation:</strong> Manual - user runs when needed for test suite optimization.</p>
     </div>
 
@@ -36,9 +36,9 @@ graph TD
     Decision -->|Yes domain-aware| Phase4a
     Decision -->|No global| Phase4aGlobal[Phase 4a: Global Workers<br/>4 workers PARALLEL]
 
-    Phase4a[Phase 4a: Global Workers<br/>4 workers PARALLEL] --> Phase4b[Phase 4b: Domain-Aware<br/>ln-374 per domain<br/>PARALLEL]
+    Phase4a[Phase 4a: Global Workers<br/>4 workers PARALLEL] --> Phase4b[Phase 4b: Domain-Aware<br/>ln-634 per domain<br/>PARALLEL]
 
-    Phase4aGlobal --> Phase4bGlobal[Phase 4b: ln-374<br/>global mode]
+    Phase4aGlobal --> Phase4bGlobal[Phase 4b: ln-634<br/>global mode]
 
     Phase4b --> Phase5[Phase 5: Aggregate<br/>Group by domain<br/>Domain Coverage Summary<br/>Calculate scores]
 
@@ -81,13 +81,13 @@ graph TB
     subgraph DomainWorkers["Domain-Aware Worker (1 x N) - Per Domain"]
         direction TB
         subgraph DomainUsers["Domain: users"]
-            W4u[ln-374<br/>Coverage Gaps]
+            W4u[ln-634<br/>Coverage Gaps]
         end
         subgraph DomainOrders["Domain: orders"]
-            W4o[ln-374<br/>Coverage Gaps]
+            W4o[ln-634<br/>Coverage Gaps]
         end
         subgraph DomainPayments["Domain: payments"]
-            W4p[ln-374<br/>Coverage Gaps]
+            W4p[ln-634<br/>Coverage Gaps]
         end
     end
 
@@ -231,7 +231,7 @@ graph LR
     <h2>Key Characteristics</h2>
     <ul>
         <li><strong>Orchestrator-Worker:</strong> L2 Coordinator + 5 L3 Workers</li>
-        <li><strong>Domain-Aware:</strong> Coverage Gaps (ln-374) runs per domain</li>
+        <li><strong>Domain-Aware:</strong> Coverage Gaps (ln-634) runs per domain</li>
         <li><strong>Global Workers:</strong> Business Logic, E2E Priority, Value, Isolation</li>
         <li><strong>Parallel Execution:</strong> All workers (global + domain-aware) run in PARALLEL</li>
         <li><strong>Domain Coverage Summary:</strong> Per-domain coverage metrics</li>


### PR DESCRIPTION
## Summary

- **ln-510**: orchestrates all 4 workers sequentially (511→512→513→514) instead of only 511+514 with ln-513 hidden inside ln-511
- **ln-200**: includes ln-230-story-prioritizer as optional Phase 4 (RICE prioritization) instead of leaving it as an orphan
- **ln-630**: fixed typo ln-374 → ln-634 in SKILL.md and diagram.html (10 occurrences)

## Test plan

- [ ] Grep for "invoked by ln-511" — should return 0 results
- [ ] Grep for "ln-374" — should return 0 results
- [ ] Grep for "internally invokes ln-513" — should return 0 results
- [ ] Verify ln-510 Worker Invocation table has 4 workers in order 511→512→513→514
- [ ] Verify ln-200 references ln-230 in workflow and Reference Files
- [ ] Verify ln-513 references ln-510 as caller (not ln-511)
- [ ] Verify ln-512 references ln-510 Phase 3 as primary trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)