### PR TITLE
Add product-manager-skills to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,12 @@ Yes — create symlinks/junctions to the plugin directory, or use `ln-004-agent-
 | **Issues** | [GitHub Issues](https://github.com/levnikolaevich/claude-code-skills/issues) |
 | **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
+## Related Projects
+
+| Project | Description |
+|---------|-------------|
+| [**Product Manager Skills**](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks — discovery, strategy, delivery, SaaS metrics, PM career coaching, AI product craft |
+
 ## Research & Influences
 
 Papers, docs, and methodologies studied and implemented in the skill architecture.


### PR DESCRIPTION
## Summary

- Adds a **Related Projects** section to the README with **product-manager-skills** by [Digidai](https://github.com/Digidai)
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks
- Covers product discovery, strategy, delivery, 32 SaaS metrics with formulas, PM career coaching (IC to CPO), and AI product craft
- Pure Markdown, zero scripts — complements the development workflow skills with product management expertise

**Source:** https://github.com/Digidai/product-manager-skills
**ClawHub:** https://clawhub.ai/Digidai/product-manager-skills