### PR TITLE
fix: update hex-graph-mcp server.json description to match README

### DIFF
--- a/mcp/hex-graph-mcp/server.json
+++ b/mcp/hex-graph-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.levnikolaevich/hex-graph-mcp",
   "title": "Hex Graph",
-  "description": "Deterministic layered code graph MCP server with framework overlays and SCIP interop.",
+  "description": "Deterministic layered code graph MCP server. Indexes codebases into a SQLite graph via tree-sitter AST, canonical symbol identities, semantic overlays, capability-first quality tooling, and optional SCIP interoperability.",
   "repository": {
     "url": "https://github.com/levnikolaevich/claude-code-skills",
     "source": "github"


### PR DESCRIPTION
The server.json for hex-graph-mcp had a truncated description ('capability-first quality tooling' missing its ending). This change syncs the description with the README's full product-line summary.