### PR TITLE
ln-222-story-replanner: add Workflow step 9 to cover PHASE_8_SELF_CHECK

### DIFF
--- a/plugins/agile-workflow/skills/ln-222-story-replanner/SKILL.md
+++ b/plugins/agile-workflow/skills/ln-222-story-replanner/SKILL.md
@@ -109,6 +109,7 @@ Managed artifact path pattern:
 6. Execute provider-specific updates.
 7. Update kanban.
 8. Return structured summary.
+9. Run the self-check (`PHASE_8_SELF_CHECK`): re-verify every Story body still contains all 9 required sections after the apply step, and fail the run if any are missing.
 
 ## Critical Rules
 


### PR DESCRIPTION
Fixes https://github.com/levnikolaevich/claude-code-skills/issues/52.

The Runtime declared nine phases ending in `PHASE_8_SELF_CHECK`, but
the Workflow only listed eight steps. Following the Workflow skipped
the self-check entirely. Add a step 9 that runs the self-check,
referencing the Definition-of-Done 9-section gate.